### PR TITLE
Align portfolio with updated resume and LinkedIn profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "",
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "",
   "type": "module",
   "version": "0.0.1",
-  "engines": {
-    "node": "20.x"
-  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -5,77 +5,62 @@ import { Icon } from "astro-icon/components";
 ---
 
 <SectionContainer id="about" title="About" iconName="mdi:account">
-    <article
-      class="mb-10 flex flex-col gap-10 max-w-[480px] mx-auto lg:max-w-full lg:flex-row"
-    >
-      <div class="flex-grow order-2 flex flex-col gap-4">
+  <article
+    class="mb-10 flex flex-col gap-10 max-w-[480px] mx-auto lg:max-w-full lg:flex-row"
+  >
+    <div class="flex-grow order-2 flex flex-col gap-4">
+      <p>
+        I'm <strong>Diego Lara Carvajal</strong>, a <strong>Full-Stack Developer</strong>
+        based in Vancouver, focused on building and maintaining production websites,
+        web platforms, internal tools, and MVP applications.
+      </p>
+
+      <p>
+        My work combines frontend development, CMS architecture, cloud infrastructure,
+        API integrations, automation, performance optimization, accessibility, and
+        technical SEO.
+      </p>
+
+      <div
+        id="moreContent"
+        class="flex flex-col gap-4 overflow-hidden max-h-0 transition-all duration-300"
+      >
         <p>
-          Welcome to my professional space! I'm <strong
-            >Diego Lara Carvajal</strong
-          >, a <strong>Web Developer</strong>
-          with a vibrant flair for crafting <b>user-friendly</b> and <b
-            >innovative digital experiences</b
-          >. Born and raised in the scenic landscapes of <b>Chile</b>, I now
-          channel my creative energy into the dynamic tech scene of <strong
-            >Vancouver, BC</strong
-          >.
+          At Rose Agency, I work on client websites and web platforms using React,
+          Astro, TypeScript, PHP, Tailwind CSS, and WordPress. I also manage
+          production environments on Cloudways and WP Engine, configure Cloudflare
+          DNS and security rules, integrate APIs and CRM systems, and develop
+          monitoring tools for uptime, SSL and domain expiration, and WordPress
+          maintenance data.
         </p>
 
         <p>
-          While my academic journey began in the field of <b>Psychology</b>,
-          it's the logical yet imaginative world of coding and design that has
-          captured my full attention. My study of the human mind has not gone to
-          waste, however; it's given me a unique perspective on <b
-            >user experience and interaction</b
-          >—skills that I now apply to every line of code I write.
+          I have also developed MVP applications across web and mobile platforms,
+          including EVDrop and Remedi, using technologies such as React Native,
+          Next.js, Supabase, Prisma, PostgreSQL, and Google Maps API.
         </p>
 
-        <div
-          id="moreContent"
-          class="flex flex-col gap-4 overflow-hidden max-h-0 transition-all duration-300"
-        >
-          <p>
-            I'm dedicated to the art of web development, constantly learning and
-            staying ahead of the curve. Whether it's a simple website tweak or a
-            complex application build, my approach is all about blending <b
-              >form with function</b
-            > to achieve a harmonious user experience.
-          </p>
-
-          <p>
-            When I'm not immersed in coding, you can find me exploring new
-            cultures through travel, challenging friends in sports, or reliving
-            my competitive days in <b>FIFA international tournaments</b>. These
-            experiences shape the creativity and passion I bring to my
-            professional work.
-          </p>
-
-          <p class="mb-4">
-            I'm on the lookout for a team that values <b>innovation</b>, a <b
-              >thirst for learning</b
-            >, and a <b>drive</b> to push the boundaries of what's possible on the
-            web.
-            <strong>Let's create something remarkable together</strong>.
-          </p>
-        </div>
-        <div
-          class="button cursor-pointer flex gap-1 items-center px-4 py-2 yell bg-yellow-600 text-black tracking-widest lg:text-lg font-semibold rounded-full w-fit mx-auto"
-        >
-          <Icon name="mdi:book-open" size={30} />
-          <button onclick="toggleContent()" id="readMoreButton"
-            >Read More</button
-          >
-        </div>
+        <p class="mb-4">
+          I completed the Web and Mobile App Design and Development program at
+          Langara College and previously studied Psychology in Chile. I work
+          professionally in English and Spanish.
+        </p>
       </div>
-      <Image
-        src="/images/diego-profile-photo.webp"
-        alt="Diego Profile Picture"
-        width={300}
-        height={300}
-        class="flex-1 rounded-full self-center lg:order-2"
-      />
-    </article>
-  </div>
+      <div
+        class="button cursor-pointer flex gap-1 items-center px-4 py-2 yell bg-yellow-600 text-black tracking-widest lg:text-lg font-semibold rounded-full w-fit mx-auto"
+      >
+        <Icon name="mdi:book-open" size={30} />
+        <button onclick="toggleContent()" id="readMoreButton">Read More</button>
+      </div>
+    </div>
+    <Image
+      src="/images/diego-profile-photo.webp"
+      alt="Diego Profile Picture"
+      width={300}
+      height={300}
+      class="flex-1 rounded-full self-center lg:order-2"
+    />
+  </article>
 </SectionContainer>
 
 <script is:inline>

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -4,29 +4,39 @@ import { Icon } from "astro-icon/components";
 import Skill from "./Skill.astro";
 const experiences = [
   {
-    date: "April 2024 - Present",
-    jobTitle: "Web Developer",
+    date: "March 2024 - Present",
+    jobTitle: "Full-Stack Web Developer",
     employer: "Rose Agency",
-    desc: "As a Web Developer at Rose Agency, I focus on building and maintaining websites from Figma designs using WordPress and headless WordPress. My work emphasizes responsive design, accessibility, and performance optimization, utilizing technologies like WordPress, JavaScript, HTML5, CSS3, Astro, Next.js, and Tailwind CSS.",
+    desc: "Build and maintain production websites, web platforms, and internal tools for agency clients using React, Astro, TypeScript, PHP, Tailwind CSS, and WordPress. Manage production environments on Cloudways and WP Engine, configure Cloudflare DNS and security rules, integrate third-party APIs and CRM systems, improve website performance and technical SEO, and develop monitoring and automation tools.",
     icons: [
       { iconName: "logos:wordpress-icon", skillName: "WordPress" },
-      { iconName: "logos:javascript", skillName: "JavaScript" },
-      { iconName: "logos:html-5", skillName: "HTML5" },
-      { iconName: "logos:css-3", skillName: "CSS3" },
+      { iconName: "logos:react", skillName: "React" },
+      { iconName: "logos:typescript-icon", skillName: "TypeScript" },
       { iconName: "logos:astro-icon", skillName: "Astro" },
-      { iconName: "logos:nextjs-icon", skillName: "Next" },
+      { iconName: "logos:nextjs-icon", skillName: "Next.js" },
       { iconName: "logos:tailwindcss-icon", skillName: "Tailwind CSS" },
       { iconName: "logos:github-icon", skillName: "GitHub" },
     ],
   },
   {
-    date: "July 2023 - Present",
+    date: "February 2024 - June 2024",
+    jobTitle: "Mobile Application Developer",
+    employer: "EVDrop",
+    desc: "Developed an MVP mobile application to help users locate electric vehicle charging stations and book charging sessions. Built mobile features with React Native and TypeScript, integrated Google Maps API, implemented authentication and backend data management using Supabase and Supabase Auth, and developed the booking system using prototype charging station location data.",
+    icons: [
+      { iconName: "logos:react", skillName: "React Native" },
+      { iconName: "logos:typescript-icon", skillName: "TypeScript" },
+      { iconName: "logos:github-icon", skillName: "GitHub" },
+    ],
+  },
+  {
+    date: "July 2023 - June 2024",
     jobTitle: "Full-Stack Developer",
     employer: "Freelance",
-    desc: "As a Full-Stack Developer, I currently specialize in designing and developing landing pages and full-stack applications, focusing on responsiveness, accessibility, and performance.",
+    desc: "Delivered websites and MVP web applications for startups and small businesses, focusing on responsive UI, performance, accessibility, lead generation, API integrations, authentication, and practical full-stack implementation.",
     icons: [
       { iconName: "logos:astro-icon", skillName: "Astro" },
-      { iconName: "logos:nextjs-icon", skillName: "Next" },
+      { iconName: "logos:nextjs-icon", skillName: "Next.js" },
       { iconName: "logos:typescript-icon", skillName: "TypeScript" },
       { iconName: "logos:tailwindcss-icon", skillName: "Tailwind CSS" },
       { iconName: "logos:prisma", skillName: "Prisma" },
@@ -35,9 +45,9 @@ const experiences = [
   },
   {
     date: "August 2023 - October 2023",
-    jobTitle: "Web Developer",
+    jobTitle: "Web Developer Intern",
     employer: "BURST Creative Group",
-    desc: "As a Web Developer at BURST Creative Group, my role involved delivering flawless website design, addressing design issues, and enhancing user engagement through innovative animations.",
+    desc: "Supported website development and quality assurance for client projects by fixing WordPress frontend issues, comparing builds against Figma and XD designs, and implementing CSS and JavaScript animations.",
     icons: [
       { iconName: "logos:javascript", skillName: "JavaScript" },
       { iconName: "logos:wordpress-icon", skillName: "WordPress" },
@@ -50,9 +60,9 @@ const experiences = [
     date: "March 2023 - June 2023",
     jobTitle: "Front-End Developer",
     employer: "Homechow.ca",
-    desc: "In my role as a Front-End Developer at Homechow.ca, I was responsible for transforming design concepts into code, creating accessible, responsive, and user-friendly pages and components for a startup food delivery service.",
+    desc: "Built responsive frontend pages and reusable components for a startup food delivery platform, translating designs into accessible interfaces using Next.js, TypeScript, and Tailwind CSS, with Storybook documentation and Cypress testing.",
     icons: [
-      { iconName: "logos:nextjs-icon", skillName: "Next" },
+      { iconName: "logos:nextjs-icon", skillName: "Next.js" },
       { iconName: "logos:typescript-icon", skillName: "TypeScript" },
       { iconName: "logos:tailwindcss-icon", skillName: "Tailwind CSS" },
       { iconName: "logos:storybook-icon", skillName: "Storybook" },

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -24,10 +24,8 @@ import Button from "./Button.astro";
         >I'm <span class="hero-name">Diego Lara Carvajal</span></span
       >
     </h1>
-    <p class="text-xl lg:text-2xl">
-      A dedicated <strong>Web Developer</strong> based in <strong
-        >Vancouver, BC</strong
-      >.
+    <p class="text-xl lg:text-2xl max-w-[560px]">
+      A <strong>Full-Stack Developer</strong> based in <strong>Vancouver, BC</strong>, focused on production web platforms, internal tools, and MVP applications.
     </p>
     <div class="flex gap-3">
       <Social />

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -6,29 +6,27 @@ import Link from "./Link.astro";
 
 const projects = [
   {
-    title: "EV Drop Tech",
-    date: "February 2024 - Present",
-    desc: "EV Drop is an app facilitating the efficient use of EV infrastructure, prioritizing accessibility and user convenience.",
+    title: "EVDrop",
+    date: "February 2024 - June 2024",
+    desc: "MVP mobile application for locating electric vehicle charging stations and booking charging sessions, built with map-based discovery, user authentication, backend data management, and a functional reservation flow using prototype charger location data.",
     imageSrc: "/images/evdrop.webp",
-    imageAlt: "EV Drop Tech Project",
+    imageAlt: "EVDrop mobile application project",
     links: [],
     icons: [
-      { iconName: "logos:react", skillName: "React" },
+      { iconName: "logos:react", skillName: "React Native" },
       { iconName: "logos:typescript-icon", skillName: "TypeScript" },
-      { iconName: "logos:nodejs-icon", skillName: "Node.js" },
-      { iconName: "logos:prisma", skillName: "Prisma" },
       { iconName: "logos:github-icon", skillName: "GitHub" },
     ],
   },
   {
     title: "Remedi App",
-    date: "September 2023 - Present",
-    desc: "Remedi is a platform that simplifies the medication request process for patients and pharmacies, enhancing healthcare accessibility and efficiency.",
+    date: "September 2023 - March 2024",
+    desc: "Full-stack MVP web application supporting medication requests between patients and pharmacies, with authentication, database-driven workflows, and core application logic.",
     imageSrc: "/images/remedi.webp",
-    imageAlt: "Remedi App Project",
+    imageAlt: "Remedi App project",
     links: [],
     icons: [
-      { iconName: "logos:nextjs-icon", skillName: "Next" },
+      { iconName: "logos:nextjs-icon", skillName: "Next.js" },
       { iconName: "logos:prisma", skillName: "Prisma" },
       { iconName: "logos:typescript-icon", skillName: "TypeScript" },
       { iconName: "logos:tailwindcss-icon", skillName: "Tailwind CSS" },
@@ -36,11 +34,30 @@ const projects = [
     ],
   },
   {
+    title: "Sentus",
+    date: "Business Website",
+    desc: "Production business website designed to showcase services, publish content, and capture leads through serverless email handling.",
+    imageSrc: null,
+    imageAlt: "",
+    links: [
+      {
+        text: "Visit Live Site",
+        url: "https://sentus.cl",
+      },
+    ],
+    icons: [
+      { iconName: "logos:astro-icon", skillName: "Astro" },
+      { iconName: "logos:javascript", skillName: "JavaScript" },
+      { iconName: "logos:tailwindcss-icon", skillName: "Tailwind CSS" },
+      { iconName: "logos:github-icon", skillName: "GitHub" },
+    ],
+  },
+  {
     title: "Inti Holística",
     date: "July 2023 - October 2023",
-    desc: "Inti Holística offers professional guidance in your personal evolution, empowering your healing journey for more conscious and free life decisions.",
+    desc: "Service-based website designed to showcase wellness services and support appointment booking through a responsive, accessible interface.",
     imageSrc: "/images/inti-ss.webp",
-    imageAlt: "Inti Holística Project",
+    imageAlt: "Inti Holística website project",
     links: [
       {
         text: "Visit Live Site",
@@ -130,7 +147,7 @@ const projects = [
   {
     projects.map((project) => (
       <article class="flex flex-col max-w-[480px] mx-auto lg:max-w-full lg:flex-row items-center border border-gray-300 rounded-lg mb-10 overflow-hidden">
-        <div class="lg:flex-1 flex flex-col justify-between p-4 leading-normal lg:order-2">
+        <div class={project.imageSrc ? "lg:flex-1 flex flex-col justify-between p-4 leading-normal lg:order-2" : "w-full flex flex-col justify-between p-4 leading-normal"}>
           <h3 class="flex items-center mb-1 text-2xl font-semibold">
             {project.title}
           </h3>
@@ -147,15 +164,17 @@ const projects = [
             ))}
           </div>
         </div>
-        <div class="lg:flex-1 w-full lg:w-1/2 flex justify-center overflow-hidden">
-          <Image
-            src={project.imageSrc}
-            alt={project.imageAlt}
-            width={480}
-            height={400}
-            class="object-cover h-[380px] w-full transition-all duration-300 hover:scale-125 lg:hover:translate-x-12 lg:hover:translate-y-10"
-          />
-        </div>
+        {project.imageSrc && (
+          <div class="lg:flex-1 w-full lg:w-1/2 flex justify-center overflow-hidden">
+            <Image
+              src={project.imageSrc}
+              alt={project.imageAlt}
+              width={480}
+              height={400}
+              class="object-cover h-[380px] w-full transition-all duration-300 hover:scale-125 lg:hover:translate-x-12 lg:hover:translate-y-10"
+            />
+          </div>
+        )}
       </article>
     ))
   }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -31,7 +31,7 @@ const { title } = Astro.props;
     <meta charset="UTF-8" />
     <meta
       name="description"
-      content="Diego Lara Carvajal - Web Developer Portfolio"
+      content="Diego Lara Carvajal - Full-Stack Developer portfolio focused on production web platforms, internal tools, performance, automation, and MVP applications."
     />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/images/logo.svg" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,7 +7,7 @@ import Hero from "../components/Hero.astro";
 import Projects from "../components/Projects.astro";
 import Layout from "../layouts/Layout.astro";
 
-const pageTitle = "Diego Lara Carvajal - Web Developer";
+const pageTitle = "Diego Lara Carvajal - Full-Stack Developer";
 ---
 
 <Layout title={pageTitle}>


### PR DESCRIPTION
## Summary
- reposition the hero and page metadata around a Full-Stack Developer profile
- rewrite the About section to reflect production websites, cloud infrastructure, API/CRM integrations, monitoring, and MVP product work
- update Experience with the current Rose Agency title and responsibilities, add EVDrop as a separate contract role, and correct Freelance dates/content
- update featured projects for EVDrop, Remedi, and Inti Holística, and add Sentus

## Notes
- EVDrop now describes the functional booking flow while clarifying that charger location data was prototype data.
- Sentus has been added as a text-only project card because no new screenshot asset was added in this change.
- Decap CMS remains represented in the LinkedIn/resume profile; a dedicated portfolio skills section can be added separately if needed after review.

## Testing
- Not run locally in this environment; changes are content and component-template updates for review.